### PR TITLE
Added the fix, plus a test

### DIFF
--- a/tests/webapp_test.py
+++ b/tests/webapp_test.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode
 import json
 
 import unittest
+from db.answer import get_answers
 from db.question import question_table, get_questions
 from db.submission import submission_table
 
@@ -72,6 +73,8 @@ class TestDokomoWebapp(unittest.TestCase):
         condition = submission_table.c.submission_id == result_submission_id
         self.assertEqual(
             submission_table.select().where(condition).execute().rowcount, 1)
+        sub_answers = get_answers(result_submission_id)
+        self.assertEqual(sub_answers.rowcount, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/webapp.py
+++ b/webapp.py
@@ -35,7 +35,7 @@ class Index(tornado.web.RequestHandler):
         survey_id = data['survey_id']
         all_answers = data['answers']
         # Filter out the skipped questions in the submission.
-        answers = (ans for ans in all_answers if 'answer' in ans)
+        answers = (ans for ans in all_answers if ans['answer'] is not None)
 
 
         with engine.begin() as connection:


### PR DESCRIPTION
A slight change in the JSON representation of a submission broke the POST logic. This fixes it and adds a test.
