### PR TITLE
Quieter travis irc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,5 @@ notifications:
       - "%{repository}@%{branch}: %{message} (%{build_url})"
     on_success: change
     on_failure: change
+  email:
+    on_failure: change


### PR DESCRIPTION
Travis introduces a lot of noise into the #sel-columbia channel... I think it's more sensible to notify only on changes to the build status, and with one line instead of three. Thoughts?
@csytan @dpapathanasiou @Snkz @myf 
