### PR TITLE
Enforce minimum length of survey id prefix

### DIFF
--- a/db/survey.py
+++ b/db/survey.py
@@ -49,6 +49,8 @@ def get_survey_id_from_prefix(survey_prefix: str) -> str:
     :raise SurveyPrefixDoesNotIdentifyASurvey: if the given prefix identifies
                                                0 or more than 1 survey
     """
+    if len(survey_prefix) < 8:
+        raise SurveyPrefixTooShortError(survey_prefix)
     survey_id_text = cast(survey_table.c.survey_id, Text)
     cond = survey_id_text.like('{}%'.format(survey_prefix))
     surveys = survey_table.select().limit(2).where(cond).execute().fetchall()
@@ -169,4 +171,8 @@ class SurveyAlreadyExistsError(Exception):
 
 
 class SurveyPrefixDoesNotIdentifyASurveyError(Exception):
+    pass
+
+
+class SurveyPrefixTooShortError(Exception):
     pass

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -26,7 +26,8 @@ from db.submission import submission_table, submission_insert, \
     submission_select, get_submissions_by_email
 from db.survey import survey_table, survey_insert, survey_select, \
     get_surveys_for_user_by_email, display, SurveyDoesNotExistError, \
-    get_survey_id_from_prefix, SurveyPrefixDoesNotIdentifyASurveyError
+    get_survey_id_from_prefix, SurveyPrefixDoesNotIdentifyASurveyError, \
+    SurveyPrefixTooShortError
 
 
 class TestAnswer(unittest.TestCase):
@@ -447,6 +448,10 @@ class TestSurvey(unittest.TestCase):
         self.assertEqual(get_survey_id_from_prefix(survey_id[:10]), survey_id)
         self.assertRaises(SurveyPrefixDoesNotIdentifyASurveyError,
                           get_survey_id_from_prefix, str(uuid.uuid4()))
+
+    def testPrefixTooShort(self):
+        self.assertRaises(SurveyPrefixTooShortError, get_survey_id_from_prefix,
+                          'a')
 
     def testDisplay(self):
         survey = survey_table.select().where(

--- a/webapp.py
+++ b/webapp.py
@@ -21,7 +21,7 @@ from pages.debug import DebugLoginHandler, DebugLogoutHandler
 import settings
 from utils.logger import setup_custom_logger
 from db.survey import SurveyPrefixDoesNotIdentifyASurveyError, \
-    get_survey_id_from_prefix
+    get_survey_id_from_prefix, SurveyPrefixTooShortError
 
 
 logger = setup_custom_logger('dokomo')
@@ -47,7 +47,8 @@ class Survey(BaseHandler):
                 self.render('survey.html',
                             survey=json_encode(survey),
                             title=survey['title'])
-        except SurveyPrefixDoesNotIdentifyASurveyError:
+        except (SurveyPrefixDoesNotIdentifyASurveyError,
+                SurveyPrefixTooShortError):
             raise tornado.web.HTTPError(404)
 
 


### PR DESCRIPTION
Not sure if 8 characters is the best choice here.

| Number of characters | Number of possibilities |
| --- | --- |
| 5 | 1.05 million |
| 6 | 16.8 million |
| 7 | 268 million |
| 8 | 4.29 billion |

[Finishes #85977010]
