### PR TITLE
Dockerfile deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.4
 WORKDIR /dokomo
-ADD requirements.txt /dokomo/
+RUN apt-get update && apt-get install npm nodejs -y
+ADD package.json /tmp/package.json
+RUN cd /tmp && npm install && npm install lodash --save-dev
+RUN cp -a /tmp/node_modules /dokomo/
+ADD . /dokomo/
 RUN pip install -r requirements.txt
 RUN head -c 24 /dev/urandom > cookie_secret
+RUN nodejs node_modules/gulp/bin/gulp.js dev-build
 EXPOSE 8888

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,11 +1,13 @@
-webapp:
+webapp-dev:
   build: .
   command: python webapp.py
+  volumes:
+      - ./:/dokomo
   links:
-    - "db:db"
+    - "db-dev:db-dev"
   ports:
     - "8888:8888"
-db:
+db-dev:
   image: "mdillon/postgis:9.4"
   environment:
     POSTGRES_PASSWORD: 'password'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 webapp:
-  build: .
+  image: "selcolumbia/dokomoforms"
   command: python webapp.py
   links:
     - "db:db"


### PR DESCRIPTION
With these changes, all you need in order to deploy Dokomo Forms is `docker-compose` (which is pip-installable (Python 2 only!)) and `docker-compose.yml`.

@jmwohl 
Note that now you will have to do:

```
$ docker-compose -f docker-compose-dev.yml up
```

This new `docker-compose-dev.yml` file has the same behavior as the old `docker-compose.yml` file. The new `docker-compose.yml` file does not mount anything as a volume.