### PR TITLE
Enumerator submission fix

### DIFF
--- a/dokomoforms/exc.py
+++ b/dokomoforms/exc.py
@@ -30,7 +30,7 @@ class NoSuchSubmissionTypeError(DokomoError):
     Raised when dokomoforms.models.submission.construct_submission
     is called with an invalid submission_type.
 
-    The valid types are 'unathenticated' and 'authenticated'
+    The valid types are 'unathenticated' and 'enumerator_only_submission'
     """
 
 

--- a/dokomoforms/handlers/api/v0/submissions.py
+++ b/dokomoforms/handlers/api/v0/submissions.py
@@ -57,7 +57,7 @@ def _create_submission(self, survey):
             ]
             self.data['answers'] = answers
 
-        self.data['submission_type'] = survey.survey_type + '_submissions'
+        self.data['submission_type'] = survey.survey_type + '_submission'
 
         submission = construct_submission(**self.data)
 

--- a/dokomoforms/handlers/api/v0/submissions.py
+++ b/dokomoforms/handlers/api/v0/submissions.py
@@ -60,7 +60,7 @@ def _create_submission(self, survey):
         # pass submission props as kwargs
         if 'submission_type' not in self.data:
             # by default fall to authenticated (i.e. EnumOnlySubmission)
-            self.data['submission_type'] = 'authenticated'
+            self.data['submission_type'] = 'enumerator_only_submission'
 
         submission = construct_submission(**self.data)
 

--- a/dokomoforms/handlers/demo.py
+++ b/dokomoforms/handlers/demo.py
@@ -97,7 +97,7 @@ def _create_demo_user(session):
         session.flush()
         survey.submissions.extend([
             models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 submitter_name='Demo Submitter 1',
                 submission_time=(
                     datetime.datetime.now() - datetime.timedelta(days=1)
@@ -135,7 +135,7 @@ def _create_demo_user(session):
                 ],
             ),
             models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 submitter_name='Demo Submitter 2',
                 submission_time=(
                     datetime.datetime.now() - datetime.timedelta(days=4)

--- a/dokomoforms/models/submission.py
+++ b/dokomoforms/models/submission.py
@@ -24,7 +24,7 @@ class Submission(Base):
     id = util.pk()
     submission_type = sa.Column(
         sa.Enum(
-            'unauthenticated', 'authenticated',
+            'public_submission', 'enumerator_only_submission',
             name='submission_type_enum', inherit_schema=True
         ),
         nullable=False,
@@ -110,7 +110,7 @@ class EnumeratorOnlySubmission(Submission):
     )
     enumerator = relationship('User')
 
-    __mapper_args__ = {'polymorphic_identity': 'authenticated'}
+    __mapper_args__ = {'polymorphic_identity': 'enumerator_only_submission'}
     __table_args__ = (
         sa.ForeignKeyConstraint(
             ['id', 'the_survey_id'], ['submission.id', 'submission.survey_id']
@@ -151,7 +151,7 @@ class PublicSubmission(Submission):
         sa.CheckConstraint("survey_type::TEXT = 'public'"),
     )
 
-    __mapper_args__ = {'polymorphic_identity': 'unauthenticated'}
+    __mapper_args__ = {'polymorphic_identity': 'public_submission'}
 
     def _asdict(self):
         result = super()._default_asdict()
@@ -171,14 +171,14 @@ def construct_submission(*, submission_type: str, **kwargs) -> Submission:
     See http://stackoverflow.com/q/30518484/1475412
 
     :param submission_type: the type of submission. Must be either
-                            'unauthenticated' or 'authenticated'
+                            'public_submission' or 'enumerator_only_submission'
     :param kwargs: the keyword arguments to pass to the constructor
     :returns: an instance of one of the Node subtypes
     :raises: dokomoforms.exc.NoSuchSubmissionTypeError
     """
-    if submission_type == 'authenticated':
+    if submission_type == 'enumerator_only_submission':
         submission_constructor = EnumeratorOnlySubmission
-    elif submission_type == 'unauthenticated':
+    elif submission_type == 'public_submission':
         submission_constructor = PublicSubmission
     else:
         raise NoSuchSubmissionTypeError(submission_type)

--- a/dokomoforms/static/src/survey/js/Application.js
+++ b/dokomoforms/static/src/survey/js/Application.js
@@ -743,7 +743,7 @@ var Application = React.createClass({
         var submission = {
             submitter_name: localStorage['submitter_name'] || 'anon',
             submitter_email: localStorage['submitter_email'] || 'anon@anon.org',
-            submission_type: 'unauthenticated', //XXX
+            submission_type: 'public_submission', //XXX
             survey_id: this.props.survey.id,
             answers: answers,
             start_time: survey.start_time || null,

--- a/dokomoforms/static/src/survey/js/Application.js
+++ b/dokomoforms/static/src/survey/js/Application.js
@@ -743,7 +743,6 @@ var Application = React.createClass({
         var submission = {
             submitter_name: localStorage['submitter_name'] || 'anon',
             submitter_email: localStorage['submitter_email'] || 'anon@anon.org',
-            submission_type: 'public_submission', //XXX
             survey_id: this.props.survey.id,
             answers: answers,
             start_time: survey.start_time || null,

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -1752,26 +1752,6 @@ class TestSurveyApi(DokoHTTPTest):
         self.assertEqual(response.code, 403, msg=response.body)
         self.assertIn('xsrf', response.body.decode())
 
-    def test_error_public_submission_to_enum_only_survey(self):
-        survey_id = 'c0816b52-204f-41d4-aaf0-ac6ae2970925'
-        # url to test
-        url = self.api_root + '/surveys/' + survey_id + '/submit'
-        # http method
-        method = 'POST'
-        # body
-        body = {
-            "submitter_name": "regular",
-            "submission_type": "public_submission"
-        }
-        # make request
-        response = self.fetch(url, method=method, body=json_encode(body))
-
-        submission_dict = json_decode(response.body)
-
-        self.assertTrue('error' in submission_dict)
-
-        self.assertEqual(response.code, 400)
-
     def test_list_submissions_to_survey(self):
         survey_id = 'b0816b52-204f-41d4-aaf0-ac6ae2970923'
         # url to test

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -1014,7 +1014,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -1041,7 +1041,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -1056,7 +1056,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": "60e56824-910c-47aa-b5c0-71493277b43f",
@@ -1107,7 +1107,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey_node.id,
@@ -1159,7 +1159,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey_node.id,
@@ -1226,7 +1226,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -1276,7 +1276,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -1330,7 +1330,7 @@ class TestSurveyApi(DokoHTTPTest):
         desired_id = str(uuid.uuid4())
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -1410,7 +1410,7 @@ class TestSurveyApi(DokoHTTPTest):
         desired_id = str(uuid.uuid4())
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -1489,7 +1489,7 @@ class TestSurveyApi(DokoHTTPTest):
         desired_id = str(uuid.uuid4())
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -1555,7 +1555,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": "80e56824-910c-47aa-b5c0-71493277b439",
@@ -1601,7 +1601,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": "80e56824-910c-47aa-b5c0-71493277b439",
@@ -1642,7 +1642,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": "80e56824-910c-47aa-b5c0-71493277b439",
@@ -1685,7 +1685,7 @@ class TestSurveyApi(DokoHTTPTest):
             "submitter_name": "regular",
             # public survey, so unauthenticated submission type -- we'll check
             # that an enumerator_id comes back in the response
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -1716,7 +1716,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "authenticated"
+            "submission_type": "enumerator_only_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -1743,7 +1743,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "authenticated"
+            "submission_type": "enumerator_only_submission"
         }
         # make request
         response = self.fetch(
@@ -1761,7 +1761,7 @@ class TestSurveyApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -1937,7 +1937,7 @@ class TestSurveyApi(DokoHTTPTest):
         with self.session.begin():
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated'
+                    submission_type='public_submission'
                 )
             )
             self.session.add(survey)
@@ -2105,7 +2105,7 @@ class TestSurveyApi(DokoHTTPTest):
         with self.session.begin():
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated'
+                    submission_type='public_submission'
                 )
             )
             self.session.add(survey)
@@ -2204,7 +2204,7 @@ class TestSubmissionApi(DokoHTTPTest):
         with self.session.begin():
             self.session.add_all([
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     survey=decimal_survey,
                     answers=[
                         models.construct_answer(
@@ -2215,7 +2215,7 @@ class TestSubmissionApi(DokoHTTPTest):
                     ],
                 ),
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     survey=decimal_survey,
                     answers=[
                         models.construct_answer(
@@ -2399,7 +2399,7 @@ class TestSubmissionApi(DokoHTTPTest):
         with self.session.begin():
             integer_survey.nodes[0].allow_dont_know = True
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=integer_survey,
                 answers=[
                     models.construct_answer(
@@ -2440,7 +2440,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=decimal_survey,
                 answers=[
                     models.construct_answer(
@@ -2480,7 +2480,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=text_survey,
                 answers=[
                     models.construct_answer(
@@ -2521,7 +2521,7 @@ class TestSubmissionApi(DokoHTTPTest):
         fake_photo_id = str(uuid.uuid4())
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=photo_survey,
                 answers=[
                     models.construct_answer(
@@ -2562,7 +2562,7 @@ class TestSubmissionApi(DokoHTTPTest):
         real_photo_id = str(uuid.uuid4())
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": photo_survey.nodes[0].id,
@@ -2628,7 +2628,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=date_survey,
                 answers=[
                     models.construct_answer(
@@ -2668,7 +2668,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=timestamp_survey,
                 answers=[
                     models.construct_answer(
@@ -2710,7 +2710,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=location_survey,
                 answers=[
                     models.construct_answer(
@@ -2756,7 +2756,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=facility_survey,
                 answers=[
                     models.construct_answer(
@@ -2819,7 +2819,7 @@ class TestSubmissionApi(DokoHTTPTest):
             multiple_choice_survey.nodes[0].node.choices = [choice]
             self.session.flush()
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=multiple_choice_survey,
                 answers=[
                     models.construct_answer(
@@ -2875,7 +2875,7 @@ class TestSubmissionApi(DokoHTTPTest):
                 ],
             )
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=multiple_choice_survey,
                 answers=[
                     models.construct_answer(
@@ -2916,7 +2916,7 @@ class TestSubmissionApi(DokoHTTPTest):
         )
         with self.session.begin():
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=time_survey,
                 answers=[
                     models.construct_answer(
@@ -2956,7 +2956,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": "b0816b52-204f-41d4-aaf0-ac6ae2970923",
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -2988,7 +2988,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -3019,7 +3019,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": "b0816b52-204f-41d4-aaf0-ac6ae2970923",
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(
@@ -3049,7 +3049,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": "b0816b52-204f-41d4-aaf0-ac6ae2970923",
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(
@@ -3071,7 +3071,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(
@@ -3101,7 +3101,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(
@@ -3122,7 +3122,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -3137,7 +3137,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             'survey_id': str(uuid.uuid4()),
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -3155,7 +3155,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated"
+            "submission_type": "public_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -3170,7 +3170,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": "b0816b52-204f-41d4-aaf0-ac6ae2970923",
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "type_constraint": "integer",
@@ -3191,7 +3191,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "type_constraint": "integer",
@@ -3212,7 +3212,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": "b0816b52-204f-41d4-aaf0-ac6ae2970923",
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     'survey_node_id': str(uuid.uuid4()),
@@ -3237,7 +3237,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     'survey_node_id': str(uuid.uuid4()),
@@ -3262,7 +3262,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": "b0816b52-204f-41d4-aaf0-ac6ae2970923",
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "start_time": "2015-09-17T20:42:20",
             "answers": [
                 {
@@ -3335,7 +3335,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [],
         }
         # make request
@@ -3388,7 +3388,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[1].id,
@@ -3448,7 +3448,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -3507,7 +3507,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -3568,7 +3568,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -3655,7 +3655,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -3747,7 +3747,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -3837,7 +3837,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -3955,7 +3955,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4080,7 +4080,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4205,7 +4205,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4334,7 +4334,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4476,7 +4476,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4587,7 +4587,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4712,7 +4712,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4823,7 +4823,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "survey_id": survey.id,
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": survey.nodes[0].id,
@@ -4871,7 +4871,7 @@ class TestSubmissionApi(DokoHTTPTest):
         # body
         body = {
             "submitter_name": "regular",
-            "submission_type": "unauthenticated",
+            "submission_type": "public_submission",
             "answers": [
                 {
                     "survey_node_id": "60e56824-910c-47aa-b5c0-71493277b43f",
@@ -4913,7 +4913,7 @@ class TestSubmissionApi(DokoHTTPTest):
             "survey_id": "c0816b52-204f-41d4-aaf0-ac6ae2970925",
             "enumerator_user_id": "a7becd02-1a3f-4c1d-a0e1-286ba121aef3",
             "submitter_name": "regular",
-            "submission_type": "authenticated"
+            "submission_type": "enumerator_only_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))
@@ -4941,7 +4941,7 @@ class TestSubmissionApi(DokoHTTPTest):
             "survey_id": "c0816b52-204f-41d4-aaf0-ac6ae2970925",
             "enumerator_user_id": "a7becd02-1a3f-4c1d-a0e1-286ba121aef3",
             "submitter_name": "regular",
-            "submission_type": "authenticated"
+            "submission_type": "enumerator_only_submission"
         }
         # make request
         response = self.fetch(
@@ -4960,7 +4960,7 @@ class TestSubmissionApi(DokoHTTPTest):
             "survey_id": "c0816b52-204f-41d4-aaf0-ac6ae2970925",
             "enumerator_user_id": "a7becd02-1a3f-4c1d-a0e1-286ba121aef3",
             "submitter_name": "regular",
-            "submission_type": "authenticated"
+            "submission_type": "enumerator_only_submission"
         }
         # make request
         response = self.fetch(
@@ -4979,7 +4979,7 @@ class TestSubmissionApi(DokoHTTPTest):
         body = {
             "enumerator_user_id": "a7becd02-1a3f-4c1d-a0e1-286ba121aef3",
             "submitter_name": "regular",
-            "submission_type": "authenticated"
+            "submission_type": "enumerator_only_submission"
         }
         # make request
         response = self.fetch(url, method=method, body=json_encode(body))

--- a/tests/python/test_model.py
+++ b/tests/python/test_model.py
@@ -212,7 +212,7 @@ class TestColumnProperties(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     answers=[
                         models.construct_answer(
                             survey_node=survey.nodes[0],
@@ -248,7 +248,7 @@ class TestColumnProperties(DokoTest):
             self.session.add(creator)
 
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=creator.surveys[0],
                 answers=[
                     models.construct_answer(
@@ -278,7 +278,7 @@ class TestColumnProperties(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     survey=survey,
                     answers=[
                         models.construct_answer(
@@ -300,7 +300,7 @@ class TestColumnProperties(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     survey=survey,
                     answers=[
                         models.construct_answer(
@@ -349,7 +349,7 @@ class TestColumnProperties(DokoTest):
             self.session.flush()
 
             submission = models.construct_submission(
-                submission_type='unauthenticated',
+                submission_type='public_submission',
                 survey=creator.surveys[0],
                 answers=[
                     models.construct_answer(
@@ -372,7 +372,7 @@ class TestColumnProperties(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.extend(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     survey=survey,
                     answers=[
                         models.construct_answer(
@@ -741,11 +741,11 @@ class TestUser(DokoTest):
                             administrators=[models.Administrator(name='adm')],
                             submissions=[
                                 models.construct_submission(
-                                    submission_type='unauthenticated',
+                                    submission_type='public_submission',
                                     submitter_name='sub1',
                                 ),
                                 models.construct_submission(
-                                    submission_type='unauthenticated',
+                                    submission_type='public_submission',
                                     submitter_name='sub2',
                                 ),
                             ],
@@ -755,11 +755,11 @@ class TestUser(DokoTest):
                             title={'English': 'public survey too'},
                             submissions=[
                                 models.construct_submission(
-                                    submission_type='unauthenticated',
+                                    submission_type='public_submission',
                                     submitter_name='sub3',
                                 ),
                                 models.construct_submission(
-                                    submission_type='unauthenticated',
+                                    submission_type='public_submission',
                                     submitter_name='sub4',
                                 ),
                             ],
@@ -774,11 +774,11 @@ class TestUser(DokoTest):
                             title={'English': 'not this survey'},
                             submissions=[
                                 models.construct_submission(
-                                    submission_type='unauthenticated',
+                                    submission_type='public_submission',
                                     submitter_name='sub5',
                                 ),
                                 models.construct_submission(
-                                    submission_type='unauthenticated',
+                                    submission_type='public_submission',
                                     submitter_name='sub6',
                                 ),
                             ],
@@ -1534,10 +1534,10 @@ class TestSurvey(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.extend([
                 models.construct_submission(
-                    submission_type='unauthenticated'
+                    submission_type='public_submission'
                 ),
                 models.construct_submission(
-                    submission_type='unauthenticated'
+                    submission_type='public_submission'
                 ),
             ])
             self.session.add(survey)
@@ -1574,11 +1574,11 @@ class TestSurvey(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.extend([
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     save_time=dateutil.parser.parse('2015/7/29 1:00'),
                 ),
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     save_time=dateutil.parser.parse('2015/7/29 2:00'),
                 ),
             ])
@@ -1622,11 +1622,11 @@ class TestSurvey(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.extend([
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     save_time=dateutil.parser.parse('2015/7/29 1:00'),
                 ),
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     save_time=dateutil.parser.parse('2015/7/29 2:00'),
                 ),
             ])
@@ -2186,7 +2186,7 @@ class TestSurvey(DokoTest):
         with self.session.begin():
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     answers=[
                         models.construct_answer(
                             type_constraint='integer',
@@ -2255,7 +2255,7 @@ class TestSurvey(DokoTest):
         with self.session.begin():
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     answers=[
                         models.construct_answer(
                             type_constraint='integer',
@@ -2321,7 +2321,7 @@ class TestSurveyNode(DokoTest):
             survey = self.session.query(models.Survey).one()
             survey.submissions.append(
                 models.construct_submission(
-                    submission_type='unauthenticated',
+                    submission_type='public_submission',
                     answers=[
                         models.construct_answer(
                             survey_node=survey.nodes[0],
@@ -4006,7 +4006,7 @@ class TestAnswer(DokoTest):
             with self.session.begin():
                 survey1.submissions.append(
                     models.construct_submission(
-                        submission_type='unauthenticated',
+                        submission_type='public_submission',
                         answers=[
                             models.construct_answer(
                                 survey_node=survey2.nodes[0],

--- a/tests/python/test_selenium.py
+++ b/tests/python/test_selenium.py
@@ -830,6 +830,7 @@ class TestAdminManageSurvey(AdminTest):
         slug_field.send_keys('slug%#;/?:@&=+$, ')
         self.click(self.drv.find_element_by_class_name('save-survey-url'))
 
+        self.wait_for_element('shareable-link')
         new_link = self.drv.find_element_by_id('shareable-link').text
         self.assertEqual(new_link, 'http://localhost:9999/enumerate/slug')
 


### PR DESCRIPTION
- semantic change around 'submission_type'
- move all survey creation type logic to server (select constructor based on survey id, not passed in 'submission_type'
