### PR TITLE
Specify Firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 addons:
   postgresql: "9.4"
-  firefox: "latest"
+  firefox: "42.0"
 
 before_install:
   - pip install coveralls flake8 coverage beautifulsoup4 py-dateutil selenium


### PR DESCRIPTION
The URL that Travis uses to pick up Firefox "latest" leads to a 404 now. Specifying the version explicitly is good enough.