### PR TITLE
moment('hh:mm a') is not a valid Date

### DIFF
--- a/dokomoforms/static/src/survey/js/components/baseComponents/ResponseField.js
+++ b/dokomoforms/static/src/survey/js/components/baseComponents/ResponseField.js
@@ -127,11 +127,11 @@ module.exports = React.createClass({
 
                 break;
             case 'timestamp':
-            case 'time':
                 //TODO: enforce min/max
                 val = moment(answer).toDate();
                 console.log('val: ', val);
                 break;
+            case 'time':
             default:
                 if (answer) {
                     val = answer;


### PR DESCRIPTION
@jmwohl 

- [ ] Please review this.

See:
https://github.com/SEL-Columbia/dokomoforms/pull/214/files?diff=unified#r45690614

For now I've just removed any checks on `'time'` but it might make sense to have some check. `moment(some_time)` doesn't work though.