### PR TITLE
Web app manifest merge

### DIFF
--- a/dokomoforms/static/manifest.json
+++ b/dokomoforms/static/manifest.json
@@ -1,6 +1,8 @@
 {
   "name": "Dokomo Forms",
-  "start_url": "/",
+  "short_name": "Dokomo Forms",
+  "start_url": "/enumerate/",
+  "scope": "/enumerate/",
   "display": "standalone",
   "icons": [
     {

--- a/dokomoforms/static/manifest.json
+++ b/dokomoforms/static/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Dokomo Forms",
+  "start_url": "/",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "static/dist/admin/img/favicon.png",
+      "sizes": "196x196",
+      "type": "image/png"
+    }
+  ],
+  "lang": "en-US"
+}

--- a/dokomoforms/static/manifest.json
+++ b/dokomoforms/static/manifest.json
@@ -4,7 +4,7 @@
   "display": "standalone",
   "icons": [
     {
-      "src": "static/dist/admin/img/favicon.png",
+      "src": "/static/dist/admin/img/favicon.png",
       "sizes": "196x196",
       "type": "image/png"
     }

--- a/dokomoforms/static/src/common/js/service-worker.js
+++ b/dokomoforms/static/src/common/js/service-worker.js
@@ -1,0 +1,1 @@
+// Nothing to see here

--- a/dokomoforms/templates/base.html
+++ b/dokomoforms/templates/base.html
@@ -16,6 +16,7 @@
     <link href="/static/dist/admin/css/admin.css" rel="stylesheet" type="text/css">
 
     <link rel="icon" href="/static/dist/admin/img/favicon.png">
+    <link rel="manifest" href="/manifest.json">
 
     <title>{{ options.organization }} Surveys -- Powered by DokomoData</title>
 </head>

--- a/dokomoforms/templates/base.html
+++ b/dokomoforms/templates/base.html
@@ -16,7 +16,7 @@
     <link href="/static/dist/admin/css/admin.css" rel="stylesheet" type="text/css">
 
     <link rel="icon" href="/static/dist/admin/img/favicon.png">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/static/manifest.json">
 
     <title>{{ options.organization }} Surveys -- Powered by DokomoData</title>
 </head>

--- a/dokomoforms/templates/view_enumerate.html
+++ b/dokomoforms/templates/view_enumerate.html
@@ -18,6 +18,20 @@
         <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,700,100' rel='stylesheet' type='text/css'>
         <link rel="icon" href="/static/dist/survey/img/favicon.png">
 	<link rel="manifest" href="/static/manifest.json">
+	<script>
+            // From https://github.com/GoogleChrome/samples/blob/cbc8098c3ebda4dda0ff894673d3847eae31648f/app-install-banner/basic-banner/index.html
+            window.addEventListener('load', function() {
+                if ('serviceWorker' in navigator) {
+                    navigator.serviceWorker.register('/static/src/common/js/service-worker.js', { scope: '/static/src/common/js/' })
+                    .then(function(r) {
+                        console.log('registered service worker');
+                    })
+                    .catch(function(error) {
+                        console.error(error);
+                    });
+                };
+            });
+	</script>
     </head>
 
     <body>

--- a/dokomoforms/templates/view_enumerate.html
+++ b/dokomoforms/templates/view_enumerate.html
@@ -17,7 +17,7 @@
 
         <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,700,100' rel='stylesheet' type='text/css'>
         <link rel="icon" href="/static/dist/survey/img/favicon.png">
-	<link rel="manifest" href="/manifest.json">
+	<link rel="manifest" href="/static/manifest.json">
     </head>
 
     <body>

--- a/dokomoforms/templates/view_enumerate.html
+++ b/dokomoforms/templates/view_enumerate.html
@@ -17,6 +17,7 @@
 
         <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,700,100' rel='stylesheet' type='text/css'>
         <link rel="icon" href="/static/dist/survey/img/favicon.png">
+	<link rel="manifest" href="/manifest.json">
     </head>
 
     <body>

--- a/tests/python/test_selenium.py
+++ b/tests/python/test_selenium.py
@@ -4079,7 +4079,8 @@ class TestEnumerate(DriverTest):
         self.sleep()
         self.wait_for_element(
             '.btn-add-facility',
-            by=By.CSS_SELECTOR
+            by=By.CSS_SELECTOR,
+            timeout=10,
         )
         # click add button
         self.click(

--- a/webapp.py
+++ b/webapp.py
@@ -152,11 +152,6 @@ class Application(tornado.web.Application):
         urls = [
             # Administrative
             url(r'/', handlers.Index, name='index'),
-            url(
-                r'/(manifest\.json)',
-                tornado.web.StaticFileHandler,
-                {'path': settings['static_path']}
-            ),
             url(r'/user/login/?', handlers.Login, name='login'),
             url(r'/user/logout/?', handlers.Logout, name='logout'),
             url(

--- a/webapp.py
+++ b/webapp.py
@@ -139,9 +139,24 @@ class Application(tornado.web.Application):
 
         sur = SurveyResource
 
+        settings = {
+            'template_path': os.path.join(_pwd, 'dokomoforms', 'templates'),
+            'static_path': os.path.join(_pwd, 'dokomoforms', 'static'),
+            'default_handler_class': handlers.NotFound,
+            'xsrf_cookies': True,
+            'cookie_secret': get_cookie_secret(),
+            'login_url': '/',
+            'debug': options.debug,
+        }
+
         urls = [
             # Administrative
             url(r'/', handlers.Index, name='index'),
+            url(
+                r'/(manifest\.json)',
+                tornado.web.StaticFileHandler,
+                {'path': settings['static_path']}
+            ),
             url(r'/user/login/?', handlers.Login, name='login'),
             url(r'/user/logout/?', handlers.Logout, name='logout'),
             url(
@@ -251,16 +266,6 @@ class Application(tornado.web.Application):
                 name='generate_token'
             ),
         ]
-
-        settings = {
-            'template_path': os.path.join(_pwd, 'dokomoforms/templates'),
-            'static_path': os.path.join(_pwd, 'dokomoforms/static'),
-            'default_handler_class': handlers.NotFound,
-            'xsrf_cookies': True,
-            'cookie_secret': get_cookie_secret(),
-            'login_url': '/',
-            'debug': options.debug,
-        }
 
         # HTTPS
         if options.https:


### PR DESCRIPTION
The manifest stuff (https://developers.google.com/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android?hl=en) seems to work but the app install banner (https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android?hl=en) doesn't seem to be quite right...